### PR TITLE
fix: appeal bug due to typo

### DIFF
--- a/src/consts/disputeStatus.js
+++ b/src/consts/disputeStatus.js
@@ -1,6 +1,6 @@
 export default Object.freeze({
   None: undefined,
   Waiting: 0,
-  Appeable: 1,
+  Appealable: 1,
   Solved: 2,
 });


### PR DESCRIPTION
Resolved a simple typo causing appeal bugs.

Reported by the [community](https://t.me/c/1654173792/2219).

Here is a deploy [preview](https://bugfix-appeal--linguo-relaunch.netlify.app/home).